### PR TITLE
Add MarshalJSON method for ProvisionParameters

### DIFF
--- a/pkg/services/dcs/types.go
+++ b/pkg/services/dcs/types.go
@@ -40,23 +40,30 @@ type MetadataParameters struct {
 
 // ProvisionParameters represent provision parameters
 type ProvisionParameters struct {
-	Capacity                 int                    `json:"capacity,omitempty"`
-	VPCID                    string                 `json:"vpc_id,omitempty"`
-	SubnetID                 string                 `json:"subnet_id,omitempty"`
-	SecurityGroupID          string                 `json:"security_group_id,omitempty"`
-	AvailabilityZones        []string               `json:"availability_zones,omitempty"`
-	Username                 string                 `json:"username,omitempty"`
-	Password                 string                 `json:"password,omitempty"`
-	Name                     string                 `json:"name,omitempty"`
-	Description              string                 `json:"description,omitempty"`
-	BackupStrategySavedays   int                    `json:"backup_strategy_savedays,omitempty"`
-	BackupStrategyBackupType string                 `json:"backup_strategy_backup_type,omitempty"`
-	BackupStrategyBackupAt   []int                  `json:"backup_strategy_backup_at,omitempty"`
-	BackupStrategyBeginAt    string                 `json:"backup_strategy_begin_at,omitempty"`
-	BackupStrategyPeriodType string                 `json:"backup_strategy_period_type,omitempty"`
-	MaintainBegin            string                 `json:"maintain_begin,omitempty"`
-	MaintainEnd              string                 `json:"maintain_end,omitempty"`
+	Capacity                 int                    `json:"capacity,omitempty" bson:"capacity,omitempty"`
+	VPCID                    string                 `json:"vpc_id,omitempty" bson:"vpc_id,omitempty"`
+	SubnetID                 string                 `json:"subnet_id,omitempty" bson:"subnet_id,omitempty"`
+	SecurityGroupID          string                 `json:"security_group_id,omitempty" bson:"security_group_id,omitempty"`
+	AvailabilityZones        []string               `json:"availability_zones,omitempty" bson:"availability_zones,omitempty"`
+	Username                 string                 `json:"username,omitempty" bson:"username,omitempty"`
+	Password                 string                 `json:"password,omitempty" bson:"password,omitempty"`
+	Name                     string                 `json:"name,omitempty" bson:"name,omitempty"`
+	Description              string                 `json:"description,omitempty" bson:"description,omitempty"`
+	BackupStrategySavedays   int                    `json:"backup_strategy_savedays,omitempty" bson:"backup_strategy_savedays,omitempty"`
+	BackupStrategyBackupType string                 `json:"backup_strategy_backup_type,omitempty" bson:"backup_strategy_backup_type,omitempty"`
+	BackupStrategyBackupAt   []int                  `json:"backup_strategy_backup_at,omitempty" bson:"backup_strategy_backup_at,omitempty"`
+	BackupStrategyBeginAt    string                 `json:"backup_strategy_begin_at,omitempty" bson:"backup_strategy_begin_at,omitempty"`
+	BackupStrategyPeriodType string                 `json:"backup_strategy_period_type,omitempty" bson:"backup_strategy_period_type,omitempty"`
+	MaintainBegin            string                 `json:"maintain_begin,omitempty" bson:"maintain_begin,omitempty"`
+	MaintainEnd              string                 `json:"maintain_end,omitempty" bson:"maintain_end,omitempty"`
 	UnknownFields            map[string]interface{} `json:"-" bson:",inline"`
+}
+
+func (f *ProvisionParameters) MarshalJSON() ([]byte, error) {
+	var j interface{}
+	b, _ := bson.Marshal(f)
+	bson.Unmarshal(b, &j)
+	return json.Marshal(&j)
 }
 
 // Collect unknown fields into "UnknownFields"

--- a/pkg/services/dms/instance/types.go
+++ b/pkg/services/dms/instance/types.go
@@ -39,17 +39,24 @@ type MetadataParameters struct {
 
 // ProvisionParameters represent provision parameters
 type ProvisionParameters struct {
-	VPCID             string                 `json:"vpc_id,omitempty"`
-	SubnetID          string                 `json:"subnet_id,omitempty"`
-	SecurityGroupID   string                 `json:"security_group_id,omitempty"`
-	AvailabilityZones []string               `json:"availability_zones,omitempty"`
-	Username          string                 `json:"username,omitempty"`
-	Password          string                 `json:"password,omitempty"`
-	Name              string                 `json:"name,omitempty"`
-	Description       string                 `json:"description,omitempty"`
-	MaintainBegin     string                 `json:"maintain_begin,omitempty"`
-	MaintainEnd       string                 `json:"maintain_end,omitempty"`
+	VPCID             string                 `json:"vpc_id,omitempty" bson:"vpc_id,omitempty"`
+	SubnetID          string                 `json:"subnet_id,omitempty" bson:"subnet_id,omitempty"`
+	SecurityGroupID   string                 `json:"security_group_id,omitempty" bson:"security_group_id,omitempty"`
+	AvailabilityZones []string               `json:"availability_zones,omitempty" bson:"availability_zones,omitempty"`
+	Username          string                 `json:"username,omitempty" bson:"username,omitempty"`
+	Password          string                 `json:"password,omitempty" bson:"password,omitempty"`
+	Name              string                 `json:"name,omitempty" bson:"name,omitempty"`
+	Description       string                 `json:"description,omitempty" bson:"description,omitempty"`
+	MaintainBegin     string                 `json:"maintain_begin,omitempty" bson:"maintain_begin,omitempty"`
+	MaintainEnd       string                 `json:"maintain_end,omitempty" bson:"maintain_end,omitempty"`
 	UnknownFields     map[string]interface{} `json:"-" bson:",inline"`
+}
+
+func (f *ProvisionParameters) MarshalJSON() ([]byte, error) {
+	var j interface{}
+	b, _ := bson.Marshal(f)
+	bson.Unmarshal(b, &j)
+	return json.Marshal(&j)
 }
 
 // Collect unknown fields into "UnknownFields"

--- a/pkg/services/dms/queue/types.go
+++ b/pkg/services/dms/queue/types.go
@@ -40,13 +40,20 @@ type MetadataParameters struct {
 
 // ProvisionParameters represent provision parameters
 type ProvisionParameters struct {
-	RedrivePolicy   string                 `json:"redrive_policy,omitempty"`
-	MaxConsumeCount int                    `json:"max_consume_count,omitempty"`
-	RetentionHours  int                    `json:"retention_hours,omitempty"`
-	QueueName       string                 `json:"queue_name,omitempty"`
-	GroupName       string                 `json:"group_name,omitempty"`
-	Description     string                 `json:"description,omitempty"`
+	RedrivePolicy   string                 `json:"redrive_policy,omitempty" bson:"redrive_policy,omitempty"`
+	MaxConsumeCount int                    `json:"max_consume_count,omitempty" bson:"max_consume_count,omitempty"`
+	RetentionHours  int                    `json:"retention_hours,omitempty" bson:"retention_hours,omitempty"`
+	QueueName       string                 `json:"queue_name,omitempty" bson:"queue_name,omitempty"`
+	GroupName       string                 `json:"group_name,omitempty" bson:"group_name,omitempty"`
+	Description     string                 `json:"description,omitempty" bson:"description,omitempty"`
 	UnknownFields   map[string]interface{} `json:"-" bson:",inline"`
+}
+
+func (f *ProvisionParameters) MarshalJSON() ([]byte, error) {
+	var j interface{}
+	b, _ := bson.Marshal(f)
+	bson.Unmarshal(b, &j)
+	return json.Marshal(&j)
 }
 
 // Collect unknown fields into "UnknownFields"

--- a/pkg/services/obs/types.go
+++ b/pkg/services/obs/types.go
@@ -33,9 +33,16 @@ type MetadataParameters struct {
 
 // ProvisionParameters represent provision parameters
 type ProvisionParameters struct {
-	BucketName    string                 `json:"bucket_name,omitempty"`
-	BucketPolicy  string                 `json:"bucket_policy,omitempty"`
+	BucketName    string                 `json:"bucket_name,omitempty" bson:"bucket_name,omitempty"`
+	BucketPolicy  string                 `json:"bucket_policy,omitempty" bson:"bucket_policy,omitempty"`
 	UnknownFields map[string]interface{} `json:"-" bson:",inline"`
+}
+
+func (f *ProvisionParameters) MarshalJSON() ([]byte, error) {
+	var j interface{}
+	b, _ := bson.Marshal(f)
+	bson.Unmarshal(b, &j)
+	return json.Marshal(&j)
 }
 
 // Collect unknown fields into "UnknownFields"

--- a/pkg/services/rds/types.go
+++ b/pkg/services/rds/types.go
@@ -42,21 +42,28 @@ type MetadataParameters struct {
 
 // ProvisionParameters represent provision parameters
 type ProvisionParameters struct {
-	SpecCode                string                 `json:"speccode,omitempty"`
-	VolumeType              string                 `json:"volume_type,omitempty"`
-	VolumeSize              int                    `json:"volume_size,omitempty"`
-	AvailabilityZone        string                 `json:"availability_zone,omitempty"`
-	VPCID                   string                 `json:"vpc_id,omitempty"`
-	SubnetID                string                 `json:"subnet_id,omitempty"`
-	SecurityGroupID         string                 `json:"security_group_id,omitempty"`
-	Name                    string                 `json:"name,omitempty"`
-	DatabasePort            string                 `json:"database_port,omitempty"`
-	DatabasePassword        string                 `json:"database_password,omitempty"`
-	BackupStrategyStarttime string                 `json:"backup_strategy_starttime,omitempty"`
-	BackupStrategyKeepdays  int                    `json:"backup_strategy_keepdays,omitempty"`
-	HAEnable                bool                   `json:"ha_enable,omitempty"`
-	HAReplicationMode       string                 `json:"ha_replicationmode,omitempty"`
+	SpecCode                string                 `json:"speccode,omitempty" bson:"speccode,omitempty"`
+	VolumeType              string                 `json:"volume_type,omitempty" bson:"volume_type,omitempty"`
+	VolumeSize              int                    `json:"volume_size,omitempty" bson:"volume_size,omitempty"`
+	AvailabilityZone        string                 `json:"availability_zone,omitempty" bson:"availability_zone,omitempty"`
+	VPCID                   string                 `json:"vpc_id,omitempty" bson:"vpc_id,omitempty"`
+	SubnetID                string                 `json:"subnet_id,omitempty" bson:"subnet_id,omitempty"`
+	SecurityGroupID         string                 `json:"security_group_id,omitempty" bson:"security_group_id,omitempty"`
+	Name                    string                 `json:"name,omitempty" bson:"name,omitempty"`
+	DatabasePort            string                 `json:"database_port,omitempty" bson:"database_port,omitempty"`
+	DatabasePassword        string                 `json:"database_password,omitempty" bson:"database_password,omitempty"`
+	BackupStrategyStarttime string                 `json:"backup_strategy_starttime,omitempty" bson:"backup_strategy_starttime,omitempty"`
+	BackupStrategyKeepdays  int                    `json:"backup_strategy_keepdays,omitempty" bson:"backup_strategy_keepdays,omitempty"`
+	HAEnable                bool                   `json:"ha_enable,omitempty" bson:"ha_enable,omitempty"`
+	HAReplicationMode       string                 `json:"ha_replicationmode,omitempty" bson:"ha_replicationmode,omitempty"`
 	UnknownFields           map[string]interface{} `json:"-" bson:",inline"`
+}
+
+func (f *ProvisionParameters) MarshalJSON() ([]byte, error) {
+	var j interface{}
+	b, _ := bson.Marshal(f)
+	bson.Unmarshal(b, &j)
+	return json.Marshal(&j)
 }
 
 // Collect unknown fields into "UnknownFields"


### PR DESCRIPTION
- Add MarshalJSON
- Add bson parameters define to avoid unmarshal known fields to unknown fields

Related-Bugs: theopenlab/openlab#75